### PR TITLE
Feature more tolerant NDBJS export

### DIFF
--- a/app/domain/export/tabular/people/participation_ndbjs_row.rb
+++ b/app/domain/export/tabular/people/participation_ndbjs_row.rb
@@ -15,6 +15,10 @@ module Export::Tabular::People
       super(participation.person, format)
     end
 
+    def j_s_number
+      entry.j_s_number.try(:gsub, /\D/, '')
+    end
+
     def gender
       { 'm' => 1, 'w' => 2 }[entry.gender]
     end
@@ -35,7 +39,11 @@ module Export::Tabular::People
         'FR' => 'F',
         'IT' => 'I',
         'AT' => 'A'
-      }[entry.country]
+    }.fetch(entry.country, 'CH')
+    end
+
+    def nationality_j_s
+      entry.nationality_j_s || 'CH'
     end
 
     def phone_private

--- a/spec/domain/export/tabular/people/participation_ndbjs_row_spec.rb
+++ b/spec/domain/export/tabular/people/participation_ndbjs_row_spec.rb
@@ -38,6 +38,27 @@ describe Export::Tabular::People::ParticipationNdbjsRow do
   it { expect(row.fetch(:activity)).to eq 1 }
   it { expect(row.fetch(:attachments)).to eq 1 }
 
+  describe 'j_s_number format' do
+    before do
+      person.j_s_number = '169-55-79'
+    end
+
+    it { expect(row.fetch(:j_s_number)).to eq '1695579' }
+  end
+
+  describe 'default nationality_j_s and country' do
+    before do
+      person.country = nil
+      person.nationality_j_s = nil
+    end
+
+    it do
+      expect(row.fetch(:country)).to eq 'CH'
+      expect(row.fetch(:nationality_j_s)).to eq 'CH'
+    end
+  end
+
+
   private
 
   def ndbjs_person


### PR DESCRIPTION
# Problem

When using hitobito as source for participant data to be added to the SportDB, often manual post processing is required (by often I mean I've had it, but did not check if anyone else has had similar experiences). The problems include:

- nationality_j_s is empty. We may assume it's 'CH'
- country is empty. We may assume it's 'CH' as well
- j_s_number is not a number, since it's saved as a string (e. g. 123-345). SportDB requires an integer here. We may just remove all non-numeric characters.

# Solution

Implemented as suggested above