### PR TITLE
add education permissions for coaches

### DIFF
--- a/app/abilities/youth/group_ability.rb
+++ b/app/abilities/youth/group_ability.rb
@@ -14,6 +14,7 @@ module Youth::GroupAbility
       permission(:group_and_below_full).may(:education).in_same_group_or_below
       permission(:layer_full).may(:education).in_same_layer
       permission(:layer_and_below_full).may(:education).in_same_layer_or_below
+      permission(:layer_and_below_read).may(:education).in_same_layer_or_below
 
       general(:education).if_layer_group
     end


### PR DESCRIPTION
add `education` permissions for `layer_and_below_read` so a coach can see the educations tab on his group