### PR TITLE
Youth-spezifische Icons in den Suchresultaten (Z-33)

### DIFF
--- a/app/decorators/youth/event_decorator.rb
+++ b/app/decorators/youth/event_decorator.rb
@@ -1,0 +1,28 @@
+# encoding: utf-8
+
+#  Copyright (c) 2020, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Youth::EventDecorator
+  extend ActiveSupport::Concern
+
+  included do
+    def as_quicksearch
+      { id: id, label: label_with_group, type: :event, icon: icon }
+    end
+  end
+
+  private
+
+  def icon
+    if model.is_a? Event::Course
+      :book
+    elsif model.is_a? Event::Camp
+      :campground
+    else
+      :'calendar-alt'
+    end
+  end
+end

--- a/lib/hitobito_youth/wagon.rb
+++ b/lib/hitobito_youth/wagon.rb
@@ -48,8 +48,11 @@ module HitobitoYouth
       EventAbility.send :include, Youth::EventAbility
       Event::ParticipationAbility.send :include, Youth::Event::ParticipationAbility
 
-      # controller
+      # decorator
+      EventDecorator.send :include, Youth::EventDecorator
       Event::ParticipationDecorator.send :include, Youth::Event::ParticipationDecorator
+
+      # controller
       PeopleFiltersController.send :include, Youth::PeopleFiltersController
       Event::ParticipationsController.send :include, Youth::Event::ParticipationsController
 


### PR DESCRIPTION
### Absicht

Die verschiedenen Typen von Suchresultaten, speziell die verschiedenen Anlasstypen im Youth-Wagon, sollen einfacher unterscheidbar sein.  

### Lösungsvorschlag

Dieser PR stützt sich auf die Änderungen im [Core-PR #962](https://github.com/hitobito/hitobito/pull/962) und definiert die Youth-spezifischen Icons für die verschiedenen Anlasstypen:  

![grafik](https://user-images.githubusercontent.com/656013/83765690-c684c680-a67b-11ea-8f55-2cd2a149500e.png)


### Verknüpfungen

* [Issue im Trello «MiData Development»](https://trello.com/c/nPOn6Kmv/33-midata-z-33-suchresultate-typ-der-resultate)
* [Diskussion im Trello «Team MiData Features»](https://trello.com/c/uawnFN18/240-priorisierung-suchresultate)