### PR TITLE
person: improve ahv_number validation message

### DIFF
--- a/app/models/youth/person.rb
+++ b/app/models/youth/person.rb
@@ -25,8 +25,12 @@ module Youth::Person
     # Allow changing the password, even if there is an invalid AHV number in the database
     return if will_save_change_to_encrypted_password? && !will_save_change_to_ahv_number?
     return unless ahv_number.present?
-    if !checksum_validate(ahv_number).valid? || ahv_number !~ AHV_NUMBER_REGEX
-      errors.add(:ahv_number, :must_be_valid_social_security_number)
+    if ahv_number !~ AHV_NUMBER_REGEX
+      errors.add(:ahv_number, :must_be_social_security_number_with_correct_format)
+      return
+    end
+    unless checksum_validate(ahv_number).valid?
+      errors.add(:ahv_number, :must_be_social_security_number_with_correct_checksum)
     end
   end
 

--- a/config/locales/models.youth.de.yml
+++ b/config/locales/models.youth.de.yml
@@ -45,4 +45,5 @@ de:
         nationality_j_s: Nationalität gemäss J+S
     errors:
       messages:
-        must_be_valid_social_security_number: muss eine gültige AHV-Nummer (756.1234.5678.97) sein
+        must_be_social_security_number_with_correct_format: muss im gültigen Format sein (756.1234.5678.97).
+        must_be_social_security_number_with_correct_checksum: muss eine gültige Prüfziffer haben.

--- a/config/locales/models.youth.en.yml
+++ b/config/locales/models.youth.en.yml
@@ -2,4 +2,5 @@ en:
   activerecord:
     errors:
       messages:
-        must_be_valid_social_security_number: must be a valid AHV number (756.1234.5678.97)
+        must_be_social_security_number_with_correct_format: must be in valid format (756.1234.5678.97).
+        must_be_social_security_number_with_correct_checksum: must have a valid checksum.

--- a/config/locales/models.youth.fr.yml
+++ b/config/locales/models.youth.fr.yml
@@ -35,4 +35,5 @@ fr:
         nationality_j_s: Nationalité selon J+S
     errors:
       messages:
-        must_be_valid_social_security_number: doit être un numéro AVS valide (756.1234.5678.97)
+        must_be_social_security_number_with_correct_format: doit être dans un format valide (756.1234.5678.97).
+        must_be_social_security_number_with_correct_checksum: doit avoir une chiffre de côntrole valide.

--- a/config/locales/models.youth.it.yml
+++ b/config/locales/models.youth.it.yml
@@ -35,4 +35,5 @@ it:
         nationality_j_s: Nazionalità secondo G+S
     errors:
       messages:
-        must_be_valid_social_security_number: deve essere un numero AVS valido (756.1234.5678.97)
+        must_be_social_security_number_with_correct_format: deve essere in formato valido (756.1234.5678.97).
+        must_be_social_security_number_with_correct_checksum: deve avere una cifra di controllo valida.

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -32,6 +32,7 @@ describe Person do
       person = Person.new
       person.ahv_number = 'malformed ahv'
       expect(person).to have(1).error_on(:ahv_number)
+      expect(person.errors.messages[:ahv_number].first).to match(/gültigen Format/)
     end
 
     it 'succeeds for ahv number with correct format' do
@@ -46,6 +47,7 @@ describe Person do
                           nationality_j_s: 'CH',
                           ahv_number: '756.1234.5678.98')
       expect(person).to have(1).error_on(:ahv_number)
+      expect(person.errors.messages[:ahv_number].first).to match(/gültige Prüfziffer/)
     end
 
     it 'can still change password even if stored ahv number is invalid' do


### PR DESCRIPTION
If the format is invalid, the checksum is not checked
and an error message for the format shown.
If the checksum is invalid, a specific error message is shown.
Also improve the translations, because the field name
is at the start.