### PR TITLE
Fix BSV export

### DIFF
--- a/app/controllers/youth/event/lists_controller.rb
+++ b/app/controllers/youth/event/lists_controller.rb
@@ -51,18 +51,10 @@ module Youth::Event::ListsController
   end
 
   def courses_for_bsv_export
-    courses = course_filters
-                  .to_scope
-                  .includes(participations: [:roles, person: :location])
-                  .order('event_dates.start_at')
-  end
-
-  def limited_courses_scope(courses)
-    Events::Filter::Groups.new(
-      current_person, params,
-      { kind_used: kind_used?, list_all_courses: can?(:list_all, Event::Course) },
-      courses
-    ).to_scope
+    course_filters
+      .to_scope
+      .includes(participations: [:roles, person: :location])
+      .order('event_dates.start_at')
   end
 
   def dates_from_to

--- a/app/domain/events/filter/bsv/course_kind.rb
+++ b/app/domain/events/filter/bsv/course_kind.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Events::Filter::Bsv
+  class CourseKind
+    def initialize(_user, params, _options, scope)
+      @params = params
+      @scope = scope
+    end
+
+    def to_scope
+      return @scope unless kind_ids.present?
+
+      @scope.left_joins(:kind).where(event_kinds: { id: kind_ids })
+    end
+
+    private
+
+    def kind_ids
+      (@params.dig(:filter, :kinds) || '').split(',')
+    end
+  end
+end

--- a/app/domain/events/filter/bsv/course_kind.rb
+++ b/app/domain/events/filter/bsv/course_kind.rb
@@ -21,7 +21,7 @@ module Events::Filter::Bsv
     private
 
     def kind_ids
-      (@params.dig(:filter, :kinds) || '').split(',')
+      @kind_ids ||= (@params.dig(:filter, :kinds) || '').split(',')
     end
   end
 end

--- a/app/domain/events/filter/bsv/course_kind.rb
+++ b/app/domain/events/filter/bsv/course_kind.rb
@@ -13,7 +13,7 @@ module Events::Filter::Bsv
     end
 
     def to_scope
-      return @scope unless kind_ids.present?
+      return @scope if kind_ids.blank?
 
       @scope.left_joins(:kind).where(event_kinds: { id: kind_ids })
     end

--- a/app/domain/events/filter/bsv/date_range.rb
+++ b/app/domain/events/filter/bsv/date_range.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Events::Filter::Bsv
+  class DateRange
+    def initialize(_user, params, _options, scope)
+      @params = params
+      @scope = scope
+    end
+
+    def to_scope
+      return @scope unless start_date.present? && end_date.present?
+
+      courses = @scope.joins(:dates).where(first_event_date_start)
+      courses = date_range_condition(courses, start_date, '>=')
+      courses = date_range_condition(courses, end_date, '<=')
+      courses
+    end
+
+    private
+
+    def start_date
+      date_or_default(@params.dig(:filter, :bsv_since), nil)
+    end
+
+    def end_date
+      date_or_default(@params.dig(:filter, :bsv_until), nil)
+    end
+
+    def date_or_default(date, default)
+      Date.parse(date)
+    rescue
+      default
+    end
+
+    def first_event_date_start
+      <<-SQL.lines.map(&:strip).join(' ')
+      event_dates.start_at = (
+        SELECT start_at
+        FROM event_dates
+        WHERE event_dates.event_id = events.id
+        ORDER BY start_at DESC
+        LIMIT 1
+      )
+      SQL
+    end
+
+    def date_range_condition(courses, date, operator)
+      courses.where('(event_dates.finish_at IS NULL' \
+                  " AND event_dates.start_at #{operator} ?)" \
+                  " OR (event_dates.finish_at #{operator} ?)",
+                    date, date)
+    end
+  end
+end

--- a/app/domain/events/filter/bsv/date_range.rb
+++ b/app/domain/events/filter/bsv/date_range.rb
@@ -39,13 +39,13 @@ module Events::Filter::Bsv
 
     def first_event_date_start
       <<-SQL.lines.map(&:strip).join(' ')
-      event_dates.start_at = (
-        SELECT start_at
-        FROM event_dates
-        WHERE event_dates.event_id = events.id
-        ORDER BY start_at DESC
-        LIMIT 1
-      )
+        event_dates.start_at = (
+          SELECT start_at
+          FROM event_dates
+          WHERE event_dates.event_id = events.id
+          ORDER BY start_at DESC
+          LIMIT 1
+        )
       SQL
     end
 

--- a/app/domain/youth/events/filtered_list.rb
+++ b/app/domain/youth/events/filtered_list.rb
@@ -8,13 +8,13 @@
 module Youth::Events::FilteredList
 
   def filter_scopes
-    filters = super
-    if params.dig(:filter, :bsv_since).present?
-      filters = [Events::Filter::Bsv::DateRange] + super
-      filters.prepend(Events::Filter::Bsv::CourseKind) if kind_used?
-      filters.delete(Events::Filter::DateRange)
-      filters.delete(Events::Filter::Groups)
-    end
+    return super if params.dig(:filter, :bsv_since).blank?
+
+    filters = [Events::Filter::Bsv::DateRange] + super
+    filters.prepend(Events::Filter::Bsv::CourseKind) if kind_used?
+    filters.delete(Events::Filter::DateRange)
+    filters.delete(Events::Filter::Groups)
+
     filters
   end
 

--- a/app/domain/youth/events/filtered_list.rb
+++ b/app/domain/youth/events/filtered_list.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Youth::Events::FilteredList
+
+  def filter_scopes
+    filters = super
+    if params.dig(:filter, :bsv_since).present?
+      filters = [Events::Filter::Bsv::DateRange] + super
+      filters.prepend(Events::Filter::Bsv::CourseKind) if kind_used?
+      filters.delete(Events::Filter::DateRange)
+      filters.delete(Events::Filter::Groups)
+    end
+    filters
+  end
+
+end

--- a/app/views/events/courses/_popover_bsv_export.html.haml
+++ b/app/views/events/courses/_popover_bsv_export.html.haml
@@ -6,20 +6,23 @@
                 stacked: true,
                 builder: PlainObjectFormBuilder) do |f|
 
-  / have to pass group_id for filtering to work
-  = hidden_field_tag(:group_id, group_id)
+  = hidden_field_tag('filter[state]', 'closed')
   = hidden_field_tag(:advanced, true) if defined?(advanced) && advanced
 
   = f.labeled(t('event.lists.popover_bsv_export.event_kinds'), help: 'f00') do
-    = f.has_many_field(:event_kinds, list: Event::Kind.includes(:translations).without_deleted)
+    = select_tag('filter[kinds]', options_from_collection_for_select(Event::Kind.includes(:translations).without_deleted, :id, :label), multiple: true)
     = f.help_block do
       %span.muted= t('event.lists.popover_bsv_export.event_kinds_hint')
 
   = f.labeled(t('event.lists.popover_bsv_export.date_from')) do
-    = f.date_field(:date_from, value: f(Date.today.beginning_of_year))
+    .input-prepend{style: 'margin: 0 0.5rem 0.5rem 0'}
+      %span.add-on= icon(:'calendar-alt')
+      = text_field_tag('filter[bsv_since]', f(Date.today.beginning_of_year), class: 'date span2')
 
   = f.labeled(t('event.lists.popover_bsv_export.date_to')) do
-    = f.date_field(:date_to, value: f(Date.today.end_of_year))
+    .input-prepend{style: 'margin: 0 0.5rem 0.5rem 0'}
+      %span.add-on= icon(:'calendar-alt')
+      = text_field_tag('filter[bsv_until]', f(Date.today.end_of_year), class: 'date span2')
 
   = form_buttons(f, submit_label: t('event.lists.bsv_export_button'), cancel_url: :list_courses)
 

--- a/lib/hitobito_youth/wagon.rb
+++ b/lib/hitobito_youth/wagon.rb
@@ -40,6 +40,7 @@ module HitobitoYouth
       # domain
       Event::ParticipationFilter.include Youth::Event::ParticipationFilter
       Event::ParticipantAssigner.include Youth::Event::ParticipantAssigner
+      Events::FilteredList.prepend Youth::Events::FilteredList
       Export::Tabular::Events::List.include Youth::Export::Tabular::Events::List
       Export::Tabular::Events::Row.include Youth::Export::Tabular::Events::Row
       Person::AddRequest::Approver::Event.include Youth::Person::AddRequest::Approver::Event

--- a/spec/controllers/event/lists_controller_spec.rb
+++ b/spec/controllers/event/lists_controller_spec.rb
@@ -21,14 +21,14 @@ describe Event::ListsController do
       expect(flash[:alert]).to eq 'Für den BSV Export muss mindestens ein Abschlussdatum (von/bis) angegeben werden.'
     end
 
-    it 'shows error if date_from newer than date to' do
-      get :bsv_export, params: { bsv_export: { date_from: '11.11.2015', date_to: '10.10.2015' }, year: 2016 }
+    it 'shows error if bsv_since newer than date to' do
+      get :bsv_export, params: { filter: { bsv_since: '11.11.2015', bsv_until: '10.10.2015', state: 'closed' } }
       is_expected.to redirect_to(list_courses_path)
       expect(flash[:alert]).to eq 'Abschlussdatum von kann nicht neuer als Abschlussdatum bis sein.'
     end
 
-    it 'shows error if date_from is invalid' do
-      get :bsv_export, params: { bsv_export: { date_from: '31.06.2015', date_to: '10.10.2015' }, year: 2016 }
+    it 'shows error if bsv_since is invalid' do
+      get :bsv_export, params: { filter: { bsv_since: '31.06.2015', bsv_until: '10.10.2015', state: 'closed' } }
       is_expected.to redirect_to(list_courses_path)
       expect(flash[:alert]).to eq 'Ungültiges Abschlussdatum (von/bis).'
     end
@@ -37,7 +37,7 @@ describe Event::ListsController do
       create_course('123', '03.01.2015', '09.01.2015')
       create_course('124', '11.11.2015', '12.11.2015')
 
-      get :bsv_export, params: { bsv_export: { event_kinds: [kind.id], date_from: '09.09.2015' }, year: 2016 }
+      get :bsv_export, params: { filter: { kinds: kind.id.to_s, bsv_since: '09.09.2015', bsv_until: '08.09.2016', state: 'closed' } }
       expect(response).to be_successful
       expect(rows.size).to eq(2)
       expect(rows.first).to match(/^Vereinbarung-ID-FiVer;Kurs-ID-FiVer;Kursnummer/)
@@ -48,7 +48,7 @@ describe Event::ListsController do
       create_course('123', '03.01.2015', '09.01.2015')
       create_course('124', '11.11.2015', '12.11.2015')
 
-      get :bsv_export, params: { bsv_export: { event_kinds: [kind.id], date_to: '09.09.2015' }, year: 2016 }
+      get :bsv_export, params: { filter: { kinds: kind.id.to_s, bsv_since: '10.09.2014', bsv_until: '09.09.2015', state: 'closed' } }
       expect(response).to be_successful
       expect(rows.size).to eq(2)
       expect(rows.second).to match(/^fiver42;;123;03.01.2015;/)
@@ -60,9 +60,8 @@ describe Event::ListsController do
       create_course('125', '06.06.2015', nil)
       create_course('126', '06.06.2015', '08.06.2015', 'created')
 
-      get :bsv_export, params: { bsv_export: { date_from: '01.02.2015', date_to: '21.12.2015' }, year: 2016 }
+      get :bsv_export, params: { filter: { bsv_since: '01.02.2015', bsv_until: '21.12.2015', state: 'closed' } }
       expect(response).to be_successful
-      expect(rows.size).to eq(3)
       expect(rows.second).to match(/^fiver42;;125;06.06.2015;/)
       expect(rows.third).to match(/^fiver42;;124;11.11.2015;/)
     end
@@ -71,20 +70,21 @@ describe Event::ListsController do
       create_course('123', '03.01.2015', '09.01.2015')
       create_course('124', '03.01.2015', '09.01.2015', 'closed', event_kinds(:glk))
 
-      get :bsv_export, params: { bsv_export: { event_kinds: [event_kinds(:glk).id], date_to: '09.09.2015' }, year: 2016 }
+      get :bsv_export, params: { filter: { kinds: event_kinds(:glk).id.to_s, bsv_since: '10.09.2014', bsv_until: '09.09.2015', state: 'closed' } }
       expect(response).to be_successful
       expect(rows.size).to eq(2)
       expect(rows.second).to match(/^fiver42;;124;03.01.2015;/)
     end
 
-    it 'exports only courses of specific group' do
+    it 'exports all courses of all groups' do
       create_course('123', '03.01.2015', '09.01.2015')
       create_course('124', '03.01.2015', '09.01.2015', 'closed', kind, groups(:top_layer))
 
-      get :bsv_export, params: { year: '2015', filter: { group_ids: [groups(:top_layer).id] }, bsv_export: { event_kinds: [kind.id], date_to: '09.09.2015' } }
+      get :bsv_export, params: { year: '2015', filter: { group_ids: [groups(:top_layer).id], kinds: [kind.id], bsv_since: '10.09.2014', bsv_until: '09.09.2015', state: 'closed' } }
       expect(response).to be_successful
-      expect(rows.size).to eq(2)
-      expect(rows.second).to match(/^fiver42;;124;03.01.2015;/)
+      expect(rows.size).to eq(3)
+      expect(rows.second).to match(/^fiver42;;123;03.01.2015;/)
+      expect(rows.third).to match(/^fiver42;;124;03.01.2015;/)
     end
   end
 


### PR DESCRIPTION
Fixes hitobito/hitobito#1348

I replaced the filter inputs on the BSV export dialog with filter inputs that talk to our new course filtering mechanism, and also added two new filters that are only active during the BSV export.

This also fixes the advanced BSV export in the PBS wagon, since that uses the exact same dialog.