### PR TITLE
The waiting-list builds upon tentatives and can be used for all event-kinds

### DIFF
--- a/app/controllers/event/tentatives_controller.rb
+++ b/app/controllers/event/tentatives_controller.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2015, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2012-2022, Pfadibewegung Schweiz. This file is part of
 #  hitobito_youth and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_youth.
@@ -58,12 +58,12 @@ class Event::TentativesController < ApplicationController
   private
 
   def tentative_participants
-    @entries ||= @event.participations.where(state: 'tentative')
+    @entries ||= @event.participations.where(state: 'tentative') # rubocop:disable Naming/MemoizedInstanceVariableName
   end
 
   def load_group_and_event
     @group = Group.find(params[:group_id])
-    @event = Event::Course.find(params[:event_id])
+    @event = Event.find(params[:event_id]) # could be any event-kind (course, camp, ...)
   end
 
   def build


### PR DESCRIPTION
This is basically a test-balloon to run the specs, which locally fails for me.

If this works, it simply does what the commit-message says: Enable finding events of all kinds because the tentatives work (potentially) on all `Event`-subclasses.