### PR TITLE
Fix invalid registration button

### DIFF
--- a/app/models/youth/event.rb
+++ b/app/models/youth/event.rb
@@ -29,7 +29,7 @@ module Youth::Event
     alias_method_chain :applicants_scope, :states
   end
 
-  def default_participation_state(_participation, for_someone_else)
+  def default_participation_state(_participation, _for_someone_else)
     possible_participation_states.first
   end
 

--- a/app/models/youth/event/course.rb
+++ b/app/models/youth/event/course.rb
@@ -103,9 +103,9 @@ module Youth::Event::Course
 
   module ClassMethods
     def application_possible
-      where(state: 'application_open').
-      where('events.application_opening_at IS NULL OR events.application_opening_at <= ?',
-            ::Time.zone.today)
+      where(state: 'application_open')
+        .where('events.application_opening_at IS NULL OR events.application_opening_at <= ?',
+               ::Time.zone.today)
     end
   end
 end

--- a/app/views/events/_actions_show.html.haml
+++ b/app/views/events/_actions_show.html.haml
@@ -1,4 +1,4 @@
-= Dropdown::Event::ParticipantAdd.for_user(self, @group, entry, current_user)
+= Dropdown::Event::ParticipantAdd.for_user(self, @group, entry, current_user) if entry.application_possible?
 = button_action_edit if can?(:update, entry)
 = button_action_destroy if can?(:destroy, entry)
 - if can?(:new, entry)

--- a/spec/features/event_registration_spec.rb
+++ b/spec/features/event_registration_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024-2024, Puzzle ITC. This file is part of
+#  hitobito_youth and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_youth.
+
+require 'spec_helper'
+
+describe 'event registration', js: true do
+  let(:user) { people(:bottom_leader) }
+  before do
+    sign_in(user)
+  end
+
+  describe 'for an Event' do
+    it 'without application window is allowed' do
+      event = Fabricate(:event)
+      expect(event.application_opening_at).to be_nil
+      expect(event.application_closing_at).to be_nil
+      expect(event).to be_application_possible
+
+      visit group_event_path(event.groups.first, event)
+
+      expect(page).to have_css('a.btn', text: 'Anmelden', exact_text: true)
+    end
+
+    it 'with currently open application window is allowed' do
+      event = Fabricate(:event, application_opening_at: 5.days.ago, application_closing_at: 5.days.from_now)
+      expect(event).to be_application_possible
+
+      visit group_event_path(event.groups.first, event)
+
+      expect(page).to have_css('a.btn', text: 'Anmelden', exact_text: true)
+    end
+
+    it 'with application window in the future is not allowed' do
+      event = Fabricate(:event, application_opening_at: 2.days.from_now, application_closing_at: 5.days.from_now)
+      expect(event).to_not be_application_possible
+
+      visit group_event_path(event.groups.first, event)
+
+      expect(page).to_not have_css('a.btn', text: 'Anmelden', exact_text: true)
+    end
+
+    it 'with application window completely in the past is not allowed' do
+      event = Fabricate(:event, application_opening_at: 5.days.ago, application_closing_at: 2.days.ago)
+      expect(event).to_not be_application_possible
+
+      visit group_event_path(event.groups.first, event)
+
+      expect(page).to_not have_css('a.btn', text: 'Anmelden', exact_text: true)
+    end
+  end
+
+  describe 'for a Course' do
+    it 'in state application_open (without dates) is allowed' do
+      course = Fabricate(:course, state: 'application_open')
+      expect(course.application_opening_at).to be_nil
+      expect(course.application_closing_at).to be_nil
+      expect(course).to be_application_possible
+
+      visit group_event_path(course.groups.first, course)
+
+      expect(page).to have_css('a.btn', text: 'Anmelden', exact_text: true)
+    end
+
+    it 'in state application_open in the past is allowed (for now)' do
+      course = Fabricate(:course, state: 'application_open', application_opening_at: 5.days.ago)
+      expect(course).to be_application_possible
+
+      visit group_event_path(course.groups.first, course)
+
+      expect(page).to have_css('a.btn', text: 'Anmelden', exact_text: true)
+    end
+
+    it 'in state application_open in the future is not allowed' do
+      course = Fabricate(:course, state: 'application_open', application_opening_at: 5.days.from_now)
+      expect(course).to_not be_application_possible
+
+      visit group_event_path(course.groups.first, course)
+
+      expect(page).to_not have_css('a.btn', text: 'Anmelden', exact_text: true)
+    end
+
+    it 'in state application_closed it not allowed' do
+      course = Fabricate(:course, state: 'application_closed')
+      expect(course).to_not be_application_possible
+
+      visit group_event_path(course.groups.first, course)
+
+      expect(page).to_not have_css('a.btn', text: 'Anmelden', exact_text: true)
+    end
+  end
+end


### PR DESCRIPTION
This hides the registration button if the application should not be possible.

For normal events, the rules (from hitobito itself) are:

- there are places left (or a waiting list available)
- the application window is open
- or there is no application window at all

For courses, the rules (from hitobito_youth) are:

- the state is "application open"
- the application window as started in the past
- the application window is not set

Wagons of organzations may have additional rules like "the application window has not closed". For most wagons the applications are definitely closed when the course has the state "application closed".

fixes hitobito/hitobito#2328