### PR TITLE
Send mails if a manager can receive them

### DIFF
--- a/app/models/youth/person.rb
+++ b/app/models/youth/person.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2015, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2012-2024, Pfadibewegung Schweiz. This file is part of
 #  hitobito_youth and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_youth.
@@ -70,5 +70,13 @@ module Youth::Person
 
   def checksum_validate(ahv_number)
     SocialSecurityNumber::Validator.new(number: ahv_number.to_s, country_code: 'ch')
+  end
+
+  def valid_email?(email = self.email)
+    if FeatureGate.enabled?('people.people_managers')
+      Person.mailing_emails_for(self).any? { |mail| super(mail) }
+    else
+      super(email)
+    end
   end
 end

--- a/app/models/youth/person.rb
+++ b/app/models/youth/person.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 #  Copyright (c) 2012-2024, Pfadibewegung Schweiz. This file is part of
 #  hitobito_youth and licensed under the Affero General Public License version 3
@@ -38,7 +38,8 @@ module Youth::Person
   def validate_ahv_number
     # Allow changing the password, even if there is an invalid AHV number in the database
     return if will_save_change_to_encrypted_password? && !will_save_change_to_ahv_number?
-    return unless ahv_number.present?
+    return if ahv_number.blank?
+
     if ahv_number !~ AHV_NUMBER_REGEX
       errors.add(:ahv_number, :must_be_social_security_number_with_correct_format)
       return
@@ -48,10 +49,10 @@ module Youth::Person
     end
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
-  def assert_either_only_managers_or_manageds
+  def assert_either_only_managers_or_manageds # rubocop:disable Metrics/CyclomaticComplexity,Metrics/AbcSize,Metrics/PerceivedComplexity
     existent_managers = people_managers.reject { |pm| pm.marked_for_destruction? }
     existent_manageds = people_manageds.reject { |pm| pm.marked_for_destruction? }
+
     if existent_managers.any? && existent_manageds.any?
       errors.add(:base, :cannot_have_managers_and_manageds)
     elsif PeopleManager.exists?(managed: existent_managers.map(&:manager_id))
@@ -60,7 +61,6 @@ module Youth::Person
       errors.add(:base, :managed_already_manager)
     end
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
 
   def and_manageds
     return [self] unless FeatureGate.enabled?('people.people_managers')

--- a/lib/hitobito_youth/wagon.rb
+++ b/lib/hitobito_youth/wagon.rb
@@ -19,9 +19,9 @@ module HitobitoYouth
       #{config.root}/app/domain
       #{config.root}/app/jobs
     ]
-    
-    # rubocop:disable Metrics/BlockLength,Metrics/LineLength
-    config.to_prepare do
+
+    # rubocop:disable Layout/LineLength
+    config.to_prepare do # rubocop:disable Metrics/BlockLength
       # extend application classes here
 
       # models
@@ -109,6 +109,7 @@ module HitobitoYouth
       # serializer
       PersonSerializer.include Youth::PersonSerializer
     end
+    # rubocop:enable Layout/LineLength
 
     initializer 'youth.add_settings' do |_app|
       Settings.add_source!(File.join(paths['config'].existent, 'settings.yml'))

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2015, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2012-2024, Pfadibewegung Schweiz. This file is part of
 #  hitobito_youth and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_youth.
@@ -78,6 +78,16 @@ describe Person do
 
        expect(top_leader).to_not be_valid
      end
+
+    it 'can provide a mail to a managed person' do
+      managed = Fabricate(:person, email: nil)
+      expect(managed).to_not be_valid_email
+      expect(bottom_member).to be_valid_email
+
+      expect do
+        managed.managers = [bottom_member]
+      end.to change(managed, :valid_email?).from(false).to(true)
+    end
   end
 
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -63,21 +63,21 @@ describe Person do
   end
 
   describe 'people managers' do
-     it 'does not allow for someone to be both manager and managed' do
-       top_leader.managers = [bottom_member]
-       top_leader.manageds = [Fabricate(:person)]
+    it 'does not allow for someone to be both manager and managed' do
+      top_leader.managers = [bottom_member]
+      top_leader.manageds = [Fabricate(:person)]
 
-       expect(top_leader).to_not be_valid
-     end
-     
-     it 'does not allow to manage someone who is manager' do
-       bottom_member.manageds = [Fabricate(:person)]
-       bottom_member.save
+      expect(top_leader).to_not be_valid
+    end
 
-       top_leader.manageds = [bottom_member]
+    it 'does not allow to manage someone who is manager' do
+      bottom_member.manageds = [Fabricate(:person)]
+      bottom_member.save
 
-       expect(top_leader).to_not be_valid
-     end
+      top_leader.manageds = [bottom_member]
+
+      expect(top_leader).to_not be_valid
+    end
 
     it 'can provide a mail to a managed person' do
       managed = Fabricate(:person, email: nil)


### PR DESCRIPTION
Currently, confirmations are only sent if the recipient has a valid mail. With the introduction of people managers (parents, caretakers, ...) this needs to be extended. Since the manager also (and mostly only) receives the mails, their "email validity" is also taken into account.

This allows for participation confirmations being sent if only a manager has a valid email, but not the managed person.

fixes hitobito/hitobito#2392