### PR TITLE
Fix rubocop LineLength namespace

### DIFF
--- a/app/helpers/youth/dropdown/event/participant_add.rb
+++ b/app/helpers/youth/dropdown/event/participant_add.rb
@@ -49,7 +49,7 @@ module Youth
         # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         def init_items_with_manageds(url_options)
           return init_items_without_manageds(url_options) if url_options[:for_someone_else]
-          return init_items_without_manageds(url_options) unless FeatureGate.enabled?('people.people_managers') # rubocop:disable Metrics/LineLength
+          return init_items_without_manageds(url_options) unless FeatureGate.enabled?('people.people_managers') # rubocop:disable Layout/LineLength
 
           template.current_user.and_manageds.each do |person|
             opts = url_options.clone


### PR DESCRIPTION
fixes this warning:
`app/helpers/youth/dropdown/event/participant_add.rb`: Metrics/LineLength has the wrong namespace - replace it with Layout/LineLength