### PR TITLE
Ensure used helper method is actually defined

### DIFF
--- a/app/helpers/event/participation_buttons.rb
+++ b/app/helpers/event/participation_buttons.rb
@@ -15,8 +15,8 @@ class Event::ParticipationButtons
     cancel: [:assigned, :applied],
     reject: [:applied],
     absent: [:assigned, :attended],
-    attend: [:absent, if: -> { @event.closed? }],
-    assign: [:absent, if: -> { !@event.closed? }]
+    attend: [:absent, if: -> { @event.possible_states.include?("closed") ? @event.closed? : nil }],
+    assign: [:absent, if: -> { @event.possible_states.include?("closed") ? @event.closed? : nil }]
   }
 
   class_attribute :i18n_keys, default: {

--- a/app/helpers/event/participation_buttons.rb
+++ b/app/helpers/event/participation_buttons.rb
@@ -16,7 +16,7 @@ class Event::ParticipationButtons
     reject: [:applied],
     absent: [:assigned, :attended],
     attend: [:absent, if: -> { @event.possible_states.include?("closed") ? @event.closed? : nil }],
-    assign: [:absent, if: -> { @event.possible_states.include?("closed") ? @event.closed? : nil }]
+    assign: [:absent, if: -> { @event.possible_states.include?("closed") ? !@event.closed? : nil }]
   }
 
   class_attribute :i18n_keys, default: {


### PR DESCRIPTION
Since the helper methods are defined based on Event#possible_states, this results in a NoMethodError in a wagon which does not define closed as a possible state

Refs: Ticket#367996
Refs: https://sentry.puzzle.ch/pitc/hitobito-backend/issues/70621/?environment=production