### PR TITLE
Change settings add source to before initialize

### DIFF
--- a/lib/hitobito_youth/wagon.rb
+++ b/lib/hitobito_youth/wagon.rb
@@ -104,7 +104,7 @@ module HitobitoYouth
     end
     # rubocop:enable Layout/LineLength
 
-    initializer "youth.add_settings" do |_app|
+    config.before_initialize do |_app|
       Settings.add_source!(File.join(paths["config"].existent, "settings.yml"))
       Settings.reload!
     end


### PR DESCRIPTION
For some reason further wagon settings.yml changes, have overwritten the Core Settings but not the Youth Settings, after changing to `config.before_initialize` it worked again.

In Youth Wagon we enable `people.people_managers.self_service_managed_creation` that should be disabled and overwritten in the SAC Wagon