### PR TITLE
Change Storage location for AHV-Number (#59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hitobito Changelog
 
+## unreleased
+
+* AHV-Nummern wurden von der Person in die Antworten zu den aktuell laufenden Anlassteilnahmen verschoben. (hitobito_youth#59)
+
 ## Version 2.3
 
 * AHV-Nummern wurde als globale Frage für alle Anlässe hinzugefügt. Es muss für jeden neuen Anlass ausgewählt werden, ob die Antwort auf diese Frage obligatorisch, optional oder versteckt sein soll. Diese Antworten dafür werden im NDS-Export des jeweiligen Anlasses berücksichtigt. (hitobito_youth#58)

--- a/app/models/youth/event/participation_contact_data.rb
+++ b/app/models/youth/event/participation_contact_data.rb
@@ -7,7 +7,7 @@ module Youth::Event::ParticipationContactData
   extend ActiveSupport::Concern
 
   included do
-    Event::ParticipationContactData.contact_attrs << :nationality_j_s << :ahv_number << :j_s_number
+    Event::ParticipationContactData.contact_attrs << :nationality_j_s << :j_s_number
     delegate(*Event::ParticipationContactData.contact_attrs, to: :person)
   end
 end

--- a/app/models/youth/person.rb
+++ b/app/models/youth/person.rb
@@ -11,7 +11,7 @@ module Youth::Person
   NATIONALITIES_J_S = %w[CH FL ANDERE].freeze
 
   included do
-    Person::SEARCHABLE_ATTRS << :ahv_number << :j_s_number
+    Person::SEARCHABLE_ATTRS << :j_s_number
 
     has_many :people_managers, foreign_key: :managed_id,
       dependent: :destroy
@@ -23,13 +23,8 @@ module Youth::Person
     has_many :manageds, through: :people_manageds
 
     validates :nationality_j_s, inclusion: {in: NATIONALITIES_J_S, allow_blank: true}
-    validates :ahv_number, ahv_number: true, unless: :skip_ahv_number_validation?
 
     validate :assert_either_only_managers_or_manageds
-  end
-
-  def skip_ahv_number_validation?
-    will_save_change_to_encrypted_password? && !will_save_change_to_ahv_number?
   end
 
   def assert_either_only_managers_or_manageds # rubocop:disable Metrics/CyclomaticComplexity,Metrics/AbcSize,Metrics/PerceivedComplexity
@@ -65,6 +60,6 @@ module Youth::Person
       .where(event_questions: {type: Event::Question::AhvNumber.sti_name})
       .where.not(answer: [nil, ""])
       .order(Event::Participation.arel_table[:updated_at].desc)
-      .last&.answer.presence || try(:ahv_number)
+      .last&.answer.presence
   end
 end

--- a/app/serializers/youth/person_serializer.rb
+++ b/app/serializers/youth/person_serializer.rb
@@ -11,7 +11,7 @@ module Youth::PersonSerializer
       map_properties :canton
 
       if options[:show_full]
-        map_properties :j_s_number, :nationality_j_s, :ahv_number
+        map_properties :j_s_number, :nationality_j_s
       end
     end
   end

--- a/app/views/event/participation_contact_datas/_fields_youth.html.haml
+++ b/app/views/event/participation_contact_datas/_fields_youth.html.haml
@@ -4,8 +4,8 @@
 -#  https://github.com/hitobito/hitobito_youth.
 
 = field_set_tag do
-  - [:ahv_number, :j_s_number].each do |a|
-    = f.labeled_input_field(a) if entry.show_attr?(a)
+  - if entry.show_attr?(:j_s_number)
+    = f.labeled_input_field(:j_s_number)
 
   - if entry.show_attr?(:nationality_j_s)
     = f.labeled_collection_select(:nationality_j_s,

--- a/app/views/people/_details_youth.html.haml
+++ b/app/views/people/_details_youth.html.haml
@@ -4,4 +4,4 @@
 -#  https://github.com/hitobito/hitobito_youth.
 
 - if show_full
-  = render_attrs(entry, :ahv_number, :j_s_number, :translated_nationality_j_s)
+  = render_attrs(entry, :j_s_number, :translated_nationality_j_s)

--- a/app/views/people/_fields_youth.html.haml
+++ b/app/views/people/_fields_youth.html.haml
@@ -4,7 +4,7 @@
 -#  https://github.com/hitobito/hitobito_youth.
 
 = field_set_tag do
-  = f.labeled_input_fields(:ahv_number, :j_s_number)
+  = f.labeled_input_field(:j_s_number)
   = f.labeled_collection_select(:nationality_j_s,
                                 Person::NATIONALITIES_J_S,
                                 :to_s, Proc.new { |n| t("activerecord.attributes.person.nationalities_j_s.#{n}") },

--- a/config/locales/models.youth.de.yml
+++ b/config/locales/models.youth.de.yml
@@ -40,7 +40,6 @@ de:
 
       person:
         canton: Wohnkanton
-        ahv_number: AHV-Nummer
         j_s_number: J+S-Nummer
         nationality_j_s: Nationalität gemäss J+S
         translated_nationality_j_s: Nationalität gemäss J+S

--- a/config/locales/models.youth.en.yml
+++ b/config/locales/models.youth.en.yml
@@ -31,7 +31,6 @@ en:
         state: Status
       person:
         canton: Canton of residence
-        ahv_number: AVS number
         j_s_number: J+S number
         nationality_j_s: Nationality according to J+S
         translated_nationality_j_s: Nationality according to J+S

--- a/config/locales/models.youth.fr.yml
+++ b/config/locales/models.youth.fr.yml
@@ -31,7 +31,6 @@ fr:
         state: Statut
       person:
         canton: Canton de domicile
-        ahv_number: Numéro AVS
         j_s_number: Numéro J+S
         nationality_j_s: Nationalité selon J+S
         translated_nationality_j_s: Nationalité selon J+S

--- a/config/locales/models.youth.it.yml
+++ b/config/locales/models.youth.it.yml
@@ -31,7 +31,6 @@ it:
         state: Stato
       person:
         canton: Cantone di domicilio
-        ahv_number: Numero AVS
         j_s_number: Numero G+S
         nationality_j_s: Nazionalità secondo G+S
         translated_nationality_j_s: Nazionalità secondo G+S

--- a/db/migrate/20250226100000_transfer_ahv_number_to_events.rb
+++ b/db/migrate/20250226100000_transfer_ahv_number_to_events.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2025-2025, Jungwacht Blauring Schweiz. This file is part of
+#  hitobito_youth and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_youth.
+
+class TransferAhvNumberToEvents < ActiveRecord::Migration[7.1]
+  def up
+    answers_lookup, ahv_number_transfer = prepare_queries
+
+    say_with_time("Checking need for transfer") do
+      if select_values(answers_lookup).blank?
+        say "No target questions found that need the AHV-Number, skipping transfer", true
+        return
+      end
+    end
+
+    say_with_time "Transferring AHV-Number to Answers" do
+      execute(ahv_number_transfer)
+    end
+
+    # remove_column does not known about CASCADE
+    execute(<<~SQL.squish)
+      ALTER TABLE "people" DROP COLUMN "ahv_number" CASCADE
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "Possible to do, but IMHO not worth it"
+  end
+
+  private
+
+  def prepare_queries
+    today = Time.zone.now.midnight
+
+    ahv_question_lookup = <<~SQL.squish
+      SELECT id
+      FROM event_questions
+      WHERE derived_from_question_id IS NULL
+      AND type = 'Event::Question::AhvNumber'
+    SQL
+
+    # event_answers.answer,
+    # event_answers.question_id,
+    # event_questions.disclosure,
+    # event_participations.person_id,
+    answers_lookup = <<~SQL.squish
+      SELECT event_answers.id, people.ahv_number
+      FROM event_answers
+        INNER JOIN event_questions ON event_answers.question_id = event_questions.id
+        INNER JOIN event_participations ON event_answers.participation_id = event_participations.id
+        INNER JOIN people ON event_participations.person_id = people.id
+        INNER JOIN events ON event_participations.event_id = events.id
+        INNER JOIN event_dates ON events.id = event_dates.event_id
+      WHERE
+        (event_dates.start_at >= '#{today}' OR event_dates.finish_at >= '#{today}')
+        AND event_questions.derived_from_question_id = (#{ahv_question_lookup})
+        AND event_answers.answer IS NULL
+        AND people.ahv_number IS NOT NULL
+        AND people.ahv_number != ''
+    SQL
+
+    ahv_number_transfer = <<~SQL.squish
+      WITH data_query AS (#{answers_lookup})
+      UPDATE event_answers
+      SET answer = data_query.ahv_number
+      FROM data_query
+      WHERE event_answers.id = data_query.id
+    SQL
+
+    [answers_lookup, ahv_number_transfer]
+  end
+end

--- a/lib/hitobito_youth/wagon.rb
+++ b/lib/hitobito_youth/wagon.rb
@@ -33,7 +33,7 @@ module HitobitoYouth
 
       TableDisplay.register_column(Person,
         TableDisplays::ShowFullColumn,
-        [:ahv_number, :j_s_number, :nationality_j_s])
+        [:j_s_number, :nationality_j_s])
 
       # domain
       Event::ParticipationFilter.include Youth::Event::ParticipationFilter
@@ -78,7 +78,7 @@ module HitobitoYouth
       Event::ParticipationsController.include Youth::Event::ParticipationsController
       Event::ParticipationContactDatasController.prepend Youth::Event::ParticipationContactDatasController
 
-      PeopleController.permitted_attrs += [:nationality_j_s, :ahv_number, :j_s_number]
+      PeopleController.permitted_attrs += [:nationality_j_s, :j_s_number]
       EventsController.permitted_attrs += [:tentative_applications]
       Event::KindsController.permitted_attrs += [:kurs_id_fiver, :vereinbarungs_id_fiver]
 

--- a/spec/domain/export/tabular/people/participation_nds_camp_spec.rb
+++ b/spec/domain/export/tabular/people/participation_nds_camp_spec.rb
@@ -10,8 +10,14 @@ require 'spec_helper'
 describe Export::Tabular::People::ParticipationsNdsCamp do
 
   let(:person) { sportdb_person }
+  let(:valid_ahv_number) { '756.1234.5678.97'}
   let(:participation) do
-    Fabricate(:event_participation, person: person, event: events(:top_course))
+    p = Fabricate(:event_participation, person: person, event: events(:top_course))
+    question = Event::Question::AhvNumber.create(disclosure: :required, question: "AHV?", event: events(:top_course))
+    answer = Event::Answer.find_by(question: question, participation: p)
+    answer.update!(answer: valid_ahv_number)
+
+    p
   end
 
   let(:list) { Export::Tabular::People::ParticipationsNdsCamp.new([participation]) }
@@ -55,7 +61,6 @@ describe Export::Tabular::People::ParticipationsNdsCamp do
               birthday: '11.06.1980',
               gender: 'm',
               j_s_number: '1695579',
-              ahv_number: '756.1234.5678.97',
               street: 'Hauptstrasse',
               housenumber: '33',
               zip_code: '4000',

--- a/spec/domain/export/tabular/people/participation_nds_row_spec.rb
+++ b/spec/domain/export/tabular/people/participation_nds_row_spec.rb
@@ -76,13 +76,6 @@ describe Export::Tabular::People::ParticipationNdsRow do
       expect(person).to receive(:last_known_ahv_number).and_call_original
     end
 
-    context "with ahv_number fallback on person" do
-      it "calls #last_known_ahv_number and returns #ahv_number" do
-        person.ahv_number = valid_ahv_number
-        is_expected.to eq(person.ahv_number)
-      end
-    end
-
     context "with ahv_number on participation" do
       it "calls #last_known_ahv_number and returns participation answer" do
         event = participation.event

--- a/spec/domain/search_strategies/person_search_spec.rb
+++ b/spec/domain/search_strategies/person_search_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe SearchStrategies::PersonSearch do
   before do
-    people(:bottom_leader).update!(j_s_number: 12345, ahv_number: "756.9217.0769.85")
+    people(:bottom_leader).update!(j_s_number: 12345)
   end
 
   describe "#search_fulltext" do
@@ -10,12 +10,6 @@ describe SearchStrategies::PersonSearch do
 
     it "finds accessible person by j_s number" do
       result = search_class(people(:bottom_leader).j_s_number.to_s).search_fulltext
-
-      expect(result).to include(people(:bottom_leader))
-    end
-
-    it "finds accessible person by ahv number" do
-      result = search_class(people(:bottom_leader).ahv_number.to_s).search_fulltext
 
       expect(result).to include(people(:bottom_leader))
     end

--- a/spec/jobs/export/event_participations_export_job_spec.rb
+++ b/spec/jobs/export/event_participations_export_job_spec.rb
@@ -19,7 +19,14 @@ describe Export::EventParticipationsExportJob do
   let(:person) { nds_person }
   let(:group) { course.groups.first }
   let(:event_role) { Fabricate(:event_role, type: Event::Role::Leader.sti_name) }
-  let(:participation) { Fabricate(:event_participation, person: person, event: course, roles: [event_role], active: true) }
+  let(:participation) do
+    p = Fabricate(:event_participation, person: person, event: course, roles: [event_role], active: true)
+    event = p.event
+    question = Event::Question::AhvNumber.create(disclosure: :required, question: "AHV?", event: event)
+    answer = Event::Answer.find_by(question: question, participation: p)
+    answer.update!(answer: '756.1234.5678.97')
+    p
+  end
   let(:event_participation_filter) { Event::ParticipationFilter.new(course, user, params) }
   let(:filename) { AsyncDownloadFile.create_name('event_participation_export', user.id) }
   let(:file) { AsyncDownloadFile.from_filename(filename, format) }
@@ -87,7 +94,6 @@ describe Export::EventParticipationsExportJob do
                        birthday: '11.06.1980',
                        gender: 'm',
                        j_s_number: '123',
-                       ahv_number: '756.1234.5678.97',
                        street: 'Str',
                        housenumber: '',
                        zip_code: '4000',

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -34,13 +34,6 @@ describe Person do
     let(:person) { top_leader }
     subject(:last_known_ahv_number) { person.last_known_ahv_number }
 
-    context "without any answers" do
-      it 'falls back on the legacy ahv number' do
-        person.ahv_number = valid_ahv_number
-        is_expected.to eq(person.ahv_number)
-      end
-    end
-
     context "with answered questions of type Event::Question::AhvNumber" do
       let(:ahv_numbers) do
         %w[756.3720.9797.95 756.7774.5627.12 756.5137.2138.68]
@@ -66,39 +59,6 @@ describe Person do
         expected_answer = ahv_number_answers.first
         expect(person.last_known_ahv_number(expected_answer.participation_id)).to eq(expected_answer.answer)
       end
-    end
-  end
-
-  describe '#ahv_number' do
-    it 'fails for malformatted ahv number' do
-      person = Person.new
-      person.ahv_number = 'malformed ahv'
-      expect(person).to have(1).error_on(:ahv_number)
-      expect(person.errors.messages[:ahv_number].first).to match(/gültigen Format/)
-    end
-
-    it 'succeeds for ahv number with correct format' do
-      person = Person.new(last_name: 'dummy',
-                          nationality_j_s: 'CH',
-                          ahv_number: '756.1234.5678.97')
-      expect(person).to be_valid
-    end
-
-    it 'fails for ahv number with wrong checksum' do
-      person = Person.new(last_name: 'dummy',
-                          nationality_j_s: 'CH',
-                          ahv_number: '756.1234.5678.98')
-      expect(person).to have(1).error_on(:ahv_number)
-      expect(person.errors.messages[:ahv_number].first).to match(/gültige Prüfziffer/)
-    end
-
-    it 'can still change password even if stored ahv number is invalid' do
-      person = Person.new(ahv_number: 'malformed', first_name: 'Jack')
-      person.save(validate: false)
-
-      expect do
-        person.password = 'mynewsuperstrongpassword'
-      end.to change(person, :valid?).from(false).to(true)
     end
   end
 

--- a/spec/regressions/event/participations_contact_datas_controller_spec.rb
+++ b/spec/regressions/event/participations_contact_datas_controller_spec.rb
@@ -23,16 +23,12 @@ describe Event::ParticipationContactDatasController, type: :controller do
   describe 'GET edit' do
 
     it 'does not show hidden contact fields' do
-
-      course.update!({ hidden_contact_attrs: ['ahv_number'] })
-
       get :edit, params: { group_id: course.groups.first.id, event_id: course.id, event_role: { type: 'Event::Course::Role::Participant' } }
 
       expect(dom).to have_selector('input#event_participation_contact_data_j_s_number')
       expect(dom).to have_selector('select#event_participation_contact_data_nationality_j_s')
 
       expect(dom).to have_no_selector('input#event_participation_contact_data_ahv_number')
-
     end
 
     it 'shows all contact fields by default' do
@@ -40,9 +36,9 @@ describe Event::ParticipationContactDatasController, type: :controller do
       get :edit, params: { group_id: course.groups.first.id, event_id: course.id, event_role: { type: 'Event::Course::Role::Participant' } }
 
       expect(dom).to have_selector('input#event_participation_contact_data_j_s_number')
-      expect(dom).to have_selector('input#event_participation_contact_data_ahv_number')
       expect(dom).to have_selector('select#event_participation_contact_data_nationality_j_s')
 
+      expect(dom).to have_no_selector('input#event_participation_contact_data_ahv_number')
     end
 
   end


### PR DESCRIPTION
Transfer all AHV-Numbers to participation of CURRENT events. It also removes all references to the AHV-Number in forms and views in the person-scope.

fixes #59 