### PR TITLE
Cleanup collection select calls 🤖

### DIFF
--- a/app/views/event/participation_contact_datas/_fields_youth.html.haml
+++ b/app/views/event/participation_contact_datas/_fields_youth.html.haml
@@ -12,5 +12,4 @@
       = f.labeled_collection_select(:nationality_j_s,
                                     Person::NATIONALITIES_J_S,
                                     :to_s, Proc.new { |n| t("activerecord.attributes.person.nationalities_j_s.#{n}") },
-                                    { include_blank: "" },
-                                    { class: 'form-select form-select-sm' })
+                                    { include_blank: "" })

--- a/app/views/people/_fields_youth.html.haml
+++ b/app/views/people/_fields_youth.html.haml
@@ -8,5 +8,4 @@
   = f.labeled_collection_select(:nationality_j_s,
                                 Person::NATIONALITIES_J_S,
                                 :to_s, Proc.new { |n| t("activerecord.attributes.person.nationalities_j_s.#{n}") },
-                                { include_blank: "" },
-                                { class: 'form-select form-select-sm' })
+                                { include_blank: "" })


### PR DESCRIPTION
Remove now-redundant class: 'form-select form-select-sm' defaults from
collection_select/labeled_collection_select calls, now that
StandardFormBuilder#collection_select applies this class by default.
